### PR TITLE
Change send list controls to buttons

### DIFF
--- a/src/popup/components/send-list.component.html
+++ b/src/popup/components/send-list.component.html
@@ -1,63 +1,68 @@
-<button
-  type="button"
+<div
+  role="group"
   *ngFor="let s of sends"
-  (click)="selectSend(s)"
-  appStopClick
-  title="{{ title }} - {{ s.name }}"
+  appA11yTitle="{{ title }}"
   class="box-content-row box-content-row-flex"
 >
-  <div class="row-main">
-    <div class="app-vault-icon">
-      <div class="icon" aria-hidden="true">
-        <i class="bwi bwi-fw bwi-lg bwi-file-text" *ngIf="s.type === sendType.Text"></i>
-        <i class="bwi bwi-fw bwi-lg bwi-file" *ngIf="s.type === sendType.File"></i>
+  <button type="button" (click)="selectSend(s)" appStopClick title="{{ title }} - {{ s.name }}">
+    <div class="row-main">
+      <div class="app-vault-icon">
+        <div class="icon" aria-hidden="true">
+          <i class="bwi bwi-fw bwi-lg bwi-file-text" *ngIf="s.type === sendType.Text"></i>
+          <i class="bwi bwi-fw bwi-lg bwi-file" *ngIf="s.type === sendType.File"></i>
+        </div>
+      </div>
+      <div class="row-main-content">
+        <span class="text">
+          {{ s.name }}
+          <ng-container *ngIf="s.disabled">
+            <i
+              class="bwi bwi-exclamation-triangle text-muted"
+              title="{{ 'disabled' | i18n }}"
+              aria-hidden="true"
+            ></i>
+            <span class="sr-only">{{ "disabled" | i18n }}</span>
+          </ng-container>
+          <ng-container *ngIf="s.password">
+            <i
+              class="bwi bwi-key text-muted"
+              title="{{ 'passwordProtected' | i18n }}"
+              aria-hidden="true"
+            ></i>
+            <span class="sr-only">{{ "passwordProtected" | i18n }}</span>
+          </ng-container>
+          <ng-container *ngIf="s.maxAccessCountReached">
+            <i
+              class="bwi bwi-ban text-muted"
+              title="{{ 'maxAccessCountReached' | i18n }}"
+              aria-hidden="true"
+            ></i>
+            <span class="sr-only">{{ "maxAccessCountReached" | i18n }}</span>
+          </ng-container>
+          <ng-container *ngIf="s.expired">
+            <i
+              class="bwi bwi-clock text-muted"
+              title="{{ 'expired' | i18n }}"
+              aria-hidden="true"
+            ></i>
+            <span class="sr-only">{{ "expired" | i18n }}</span>
+          </ng-container>
+          <ng-container *ngIf="s.pendingDelete">
+            <i
+              class="bwi bwi-trash text-muted"
+              title="{{ 'pendingDeletion' | i18n }}"
+              aria-hidden="true"
+            ></i>
+            <span class="sr-only">{{ "pendingDeletion" | i18n }}</span>
+          </ng-container>
+        </span>
+        <span class="detail">{{ s.deletionDate | date: "medium" }}</span>
       </div>
     </div>
-    <div class="row-main-content">
-      <span class="text">
-        {{ s.name }}
-        <ng-container *ngIf="s.disabled">
-          <i
-            class="bwi bwi-exclamation-triangle text-muted"
-            title="{{ 'disabled' | i18n }}"
-            aria-hidden="true"
-          ></i>
-          <span class="sr-only">{{ "disabled" | i18n }}</span>
-        </ng-container>
-        <ng-container *ngIf="s.password">
-          <i
-            class="bwi bwi-key text-muted"
-            title="{{ 'passwordProtected' | i18n }}"
-            aria-hidden="true"
-          ></i>
-          <span class="sr-only">{{ "passwordProtected" | i18n }}</span>
-        </ng-container>
-        <ng-container *ngIf="s.maxAccessCountReached">
-          <i
-            class="bwi bwi-ban text-muted"
-            title="{{ 'maxAccessCountReached' | i18n }}"
-            aria-hidden="true"
-          ></i>
-          <span class="sr-only">{{ "maxAccessCountReached" | i18n }}</span>
-        </ng-container>
-        <ng-container *ngIf="s.expired">
-          <i class="bwi bwi-clock text-muted" title="{{ 'expired' | i18n }}" aria-hidden="true"></i>
-          <span class="sr-only">{{ "expired" | i18n }}</span>
-        </ng-container>
-        <ng-container *ngIf="s.pendingDelete">
-          <i
-            class="bwi bwi-trash text-muted"
-            title="{{ 'pendingDeletion' | i18n }}"
-            aria-hidden="true"
-          ></i>
-          <span class="sr-only">{{ "pendingDeletion" | i18n }}</span>
-        </ng-container>
-      </span>
-      <span class="detail">{{ s.deletionDate | date: "medium" }}</span>
-    </div>
-  </div>
+  </button>
   <div class="action-buttons">
-    <span
+    <button
+      type="button"
       class="row-btn"
       appStopClick
       appStopProp
@@ -65,10 +70,12 @@
       (click)="copySendLink(s)"
     >
       <i class="bwi bwi-lg bwi-files" aria-hidden="true"></i>
-    </span>
-    <span
+    </button>
+    <button
+      type="button"
       class="row-btn"
       [ngClass]="{ disabled: disabledByPolicy }"
+      [attr.disabled]="!disabledByPolicy ? '' : null"
       appStopClick
       appStopProp
       appA11yTitle="{{ 'removePassword' | i18n }}"
@@ -76,8 +83,9 @@
       *ngIf="s.password"
     >
       <i class="bwi bwi-lg bwi-undo" aria-hidden="true"></i>
-    </span>
-    <span
+    </button>
+    <button
+      type="button"
       class="row-btn"
       appStopClick
       appStopProp
@@ -85,6 +93,6 @@
       (click)="delete(s)"
     >
       <i class="bwi bwi-lg bwi-trash" aria-hidden="true"></i>
-    </span>
+    </button>
   </div>
-</button>
+</div>


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Currently, the controls to "Copy send link" and "Delete" etc in the sends list are not keyboard focusable/operable, as they're implemented as `<span>`s inside the single `<button>` for each send. This PR splits them out into separate `<button>` elements (similar to the work done in https://github.com/bitwarden/browser/pull/2507

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **file.ext:** Description of what was changed and why

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Testing requirements

<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

## Before you submit

- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
