### PR TITLE
Fix directory for browser's Crowdin push config

### DIFF
--- a/.github/workflows/build-browser.yml
+++ b/.github/workflows/build-browser.yml
@@ -206,7 +206,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CROWDIN_API_TOKEN: ${{ steps.retrieve-secrets.outputs.crowdin-api-token }}
         with:
-          config: crowdin.yml
+          config: apps/browser/crowdin.yml
           crowdin_branch_name: master
           upload_sources: true
           upload_translations: false


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

After the move to the mono-repo the browsers build action to push to Crowdin was failing as it could not find the configuration file.

https://github.com/bitwarden/bitwarden/runs/6289099115?check_suite_focus=true

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **.github/workflows/build-browser.yml:** Fix path to Crowdin config.yml

## Before you submit

- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [X] This change has particular **deployment requirements** (notify the DevOps team)
